### PR TITLE
解决 isntall 失败等问题 和 IllegalStateException: PathVariable annotation was empty on param 0 异常

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>chat.qiye.wechat</groupId>
@@ -174,19 +174,19 @@
         </configuration>
       </plugin>
       <!-- doc plugin，Maven API文档生成插件 -->
-<!--      <plugin>-->
-<!--        <groupId>org.apache.maven.plugins</groupId>-->
-<!--        <artifactId>maven-javadoc-plugin</artifactId>-->
-<!--        <version>3.0.1</version>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>attach-javadocs</id>-->
-<!--            <goals>-->
-<!--              <goal>jar</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
+      <!--      <plugin>-->
+      <!--        <groupId>org.apache.maven.plugins</groupId>-->
+      <!--        <artifactId>maven-javadoc-plugin</artifactId>-->
+      <!--        <version>3.0.1</version>-->
+      <!--        <executions>-->
+      <!--          <execution>-->
+      <!--            <id>attach-javadocs</id>-->
+      <!--            <goals>-->
+      <!--              <goal>jar</goal>-->
+      <!--            </goals>-->
+      <!--          </execution>-->
+      <!--        </executions>-->
+      <!--      </plugin>-->
 
       <!-- resources plugin，Maven 资源插件 -->
       <plugin>
@@ -245,6 +245,24 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.4.2</version>
+      </plugin>
+
+      <!-- 跳过单元测试 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.6</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+
       </plugin>
     </plugins>
   </build>

--- a/qiye-wechat-sdk/pom.xml
+++ b/qiye-wechat-sdk/pom.xml
@@ -61,4 +61,29 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- 跳过单元测试 -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <skipTests>true</skipTests>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+
+                </plugin>
+
+            </plugins>
+        </pluginManagement>
+    </build>
+
 </project>

--- a/qiye-wechat-sdk/src/main/java/chat/qiye/wechat/sdk/api/contact/ContactUserApi.java
+++ b/qiye-wechat-sdk/src/main/java/chat/qiye/wechat/sdk/api/contact/ContactUserApi.java
@@ -35,162 +35,162 @@ import feign.RequestLine;
 @QiYeWeChatApi(appType = AppTypeEnum.APP_CONTACT)
 public interface ContactUserApi {
 
-  /**
-   * 获取 获取部门成员列表详情
-   *
-   * @param id 部门id
-   * @param fetchChild  1/0：是否递归获取子部门下面的成员
-   * @return {@link ContactUserListResp}
-   */
-  @RequestLine(BaseApiUris.API_USER_LIST)
-  ContactUserListResp list(@Param("department_id") Integer id, @Param(value = "fetch_child") Integer fetchChild);
+    /**
+     * 获取 获取部门成员列表详情
+     *
+     * @param id 部门id
+     * @param fetchChild  1/0：是否递归获取子部门下面的成员
+     * @return {@link ContactUserListResp}
+     */
+    @RequestLine(BaseApiUris.API_USER_LIST)
+    ContactUserListResp list(@Param("department_id") Integer id, @Param(value = "fetch_child") Integer fetchChild);
 
-  /**
-   * 获取 部门下成员
-   *
-   * @param id 部门id
-   * @param fetchChild  1/0：是否递归获取子部门下面的成员
-   * @return {@link ContactUserListResp}
-   */
-  @RequestLine(BaseApiUris.API_USER_SIMPLE_LIST)
-  ContactUserListResp simpleList(@Param("department_id") Integer id, @Param(value = "fetch_child") Integer fetchChild);
+    /**
+     * 获取 部门下成员
+     *
+     * @param id 部门id
+     * @param fetchChild  1/0：是否递归获取子部门下面的成员
+     * @return {@link ContactUserListResp}
+     */
+    @RequestLine(BaseApiUris.API_USER_SIMPLE_LIST)
+    ContactUserListResp simpleList(@Param("department_id") Integer id, @Param(value = "fetch_child") Integer fetchChild);
 
-  /**
-   * 根据 userid 读取 通讯录成员
-   * https://work.weixin.qq.com/api/doc/90000/90135/90196
-   * @param userid 通讯录 用户id
-   * @return {@link ContactUserGetResp}
-   */
-  @RequestLine(BaseApiUris.API_USER_GET)
-  ContactUserGetResp get(@Param("userid") String userid);
+    /**
+     * 根据 userid 读取 通讯录成员
+     * https://work.weixin.qq.com/api/doc/90000/90135/90196
+     * @param userid 通讯录 用户id
+     * @return {@link ContactUserGetResp}
+     */
+    @RequestLine(BaseApiUris.API_USER_GET)
+    ContactUserGetResp get(@Param("userid") String userid);
 
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/90195
-   * @param userReq
-   * @return {@link RespStatus}
-   */
-  @RequestLine(BaseApiUris.API_USER_CREATE)
-  RespStatus create(ContactUserParam userReq);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/90195
+     * @param userReq
+     * @return {@link RespStatus}
+     */
+    @RequestLine(BaseApiUris.API_USER_CREATE)
+    RespStatus create(ContactUserParam userReq);
 
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/90197
-   * @param userReq
-   * @return {@link RespStatus}
-   */
-  @RequestLine(BaseApiUris.API_USER_UPDATE)
-  RespStatus update(ContactUserParam userReq);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/90197
+     * @param userReq
+     * @return {@link RespStatus}
+     */
+    @RequestLine(BaseApiUris.API_USER_UPDATE)
+    RespStatus update(ContactUserParam userReq);
 
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/90198
-   *
-   * @param userid
-   * @return {@link RespStatus}
-   */
-  @RequestLine(BaseApiUris.API_USER_DELETE)
-  RespStatus delete(@Param String userid);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/90198
+     *
+     * @param userid
+     * @return {@link RespStatus}
+     */
+    @RequestLine(BaseApiUris.API_USER_DELETE)
+    RespStatus delete(@Param("userid") String userid);
 
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/90199
-   *
-   * @param deleteReq
-   * @return {@link RespStatus}
-   */
-  @RequestLine(BaseApiUris.API_USER_DELETE_BATCH)
-  RespStatus deleteBatch(ContactUserBatchDeleteParam deleteReq);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/90199
+     *
+     * @param deleteReq
+     * @return {@link RespStatus}
+     */
+    @RequestLine(BaseApiUris.API_USER_DELETE_BATCH)
+    RespStatus deleteBatch(ContactUserBatchDeleteParam deleteReq);
 
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/90202
-   *
-   * @param param
-   * @return {@link ContactToOpenIdResp}
-   */
-  @RequestLine(BaseApiUris.API_USER_TO_OPENID)
-  ContactToOpenIdResp toOpenId(ContactToOpenIdParam param);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/90202
+     *
+     * @param param
+     * @return {@link ContactToOpenIdResp}
+     */
+    @RequestLine(BaseApiUris.API_USER_TO_OPENID)
+    ContactToOpenIdResp toOpenId(ContactToOpenIdParam param);
 
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/90202
-   *
-   * @param param
-   * @return {@link ContactToUserIdResp}
-   */
-  @RequestLine(BaseApiUris.API_USER_TO_USERID)
-  ContactToUserIdResp toUserid(ContactToUserIdParam param);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/90202
+     *
+     * @param param
+     * @return {@link ContactToUserIdResp}
+     */
+    @RequestLine(BaseApiUris.API_USER_TO_USERID)
+    ContactToUserIdResp toUserid(ContactToUserIdParam param);
 
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/90203
-   *
-   * @param userid
-   * @return {@link RespStatus}
-   */
-  @RequestLine(BaseApiUris.API_USER_AUTHSUCC)
-  RespStatus authsucc(@Param String userid);
-
-
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/90975
-   *
-   * @param param
-   * @return {@link RespStatus}
-   */
-  @RequestLine(BaseApiUris.API_USER_INVITE)
-  RespStatus invite(ContactInviteParam param);
-
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/91714
-   *
-   * @param type qrcode尺寸类型，1: 171 x 171; 2: 399 x 399; 3: 741 x 741; 4: 2052 x 2052
-   * @return {@link GetJoinQrcodeResp}
-   */
-  @RequestLine(BaseApiUris.API_GET_JOIN_QRCODE)
-  GetJoinQrcodeResp getJoinQrcode(@Param("size_type") Integer type);
-
-  /**
-   * https://work.weixin.qq.com/api/doc/90000/90135/92714
-   *
-   * @param param
-   * @return {@link GetActiveStatResp}
-   */
-  @RequestLine(BaseApiUris.API_GET_ACTIVE_STAT)
-  GetActiveStatResp getActiveStat(GetActiveStatParam param);
-
-  /**
-   * 第三方 专属接口
-   *
-   * 手机号获取userid,通过手机号获取其所对应的userid。
-   *
-   * https://work.weixin.qq.com/api/doc/90001/90143/91693
-   * @param param 请求参数
-   * @return {@link GetUserIdResp}
-   */
-  @RequestLine(BaseApiUris.API_USER_GET_USERID)
-  GetUserIdResp getUserIdByPhone(GetUserIdParam param);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/90203
+     *
+     * @param userid
+     * @return {@link RespStatus}
+     */
+    @RequestLine(BaseApiUris.API_USER_AUTHSUCC)
+    RespStatus authsucc(@Param("userid") String userid);
 
 
-  /**
-   * 第三方 专属接口
-   *
-   * 获取成员授权列表,当企业当前授权模式为成员授权时，可调用该接口获取成员授权列表。
-   *
-   * https://work.weixin.qq.com/api/doc/90001/90143/94513
-   *
-   * @param param 请求参数
-   * @return {@link AuthMemberListResp}
-   */
-  @RequestLine(BaseApiUris.API_USER_AUTH_MEMBER_LIST)
-  AuthMemberListResp getAuthMemberList(AuthMemberListParam param);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/90975
+     *
+     * @param param
+     * @return {@link RespStatus}
+     */
+    @RequestLine(BaseApiUris.API_USER_INVITE)
+    RespStatus invite(ContactInviteParam param);
 
-  /**
-   *  第三方 专属接口
-   *
-   * 查询成员用户是否已授权
-   *
-   * 当企业当前授权模式为成员授权时，可调用该接口查询成员用户是否已授权
-   *
-   * https://work.weixin.qq.com/api/doc/90001/90143/94514
-   *
-   * @param param 请求参数
-   * @return {@link CheckMemberAuthResp}
-   */
-  @RequestLine(BaseApiUris.API_USER_CHECK_MEMBER_AUTH)
-  CheckMemberAuthResp checkMemberAuth(CheckMemberAuthParam param);
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/91714
+     *
+     * @param type qrcode尺寸类型，1: 171 x 171; 2: 399 x 399; 3: 741 x 741; 4: 2052 x 2052
+     * @return {@link GetJoinQrcodeResp}
+     */
+    @RequestLine(BaseApiUris.API_GET_JOIN_QRCODE)
+    GetJoinQrcodeResp getJoinQrcode(@Param("size_type") Integer type);
+
+    /**
+     * https://work.weixin.qq.com/api/doc/90000/90135/92714
+     *
+     * @param param
+     * @return {@link GetActiveStatResp}
+     */
+    @RequestLine(BaseApiUris.API_GET_ACTIVE_STAT)
+    GetActiveStatResp getActiveStat(GetActiveStatParam param);
+
+    /**
+     * 第三方 专属接口
+     *
+     * 手机号获取userid,通过手机号获取其所对应的userid。
+     *
+     * https://work.weixin.qq.com/api/doc/90001/90143/91693
+     * @param param 请求参数
+     * @return {@link GetUserIdResp}
+     */
+    @RequestLine(BaseApiUris.API_USER_GET_USERID)
+    GetUserIdResp getUserIdByPhone(GetUserIdParam param);
+
+
+    /**
+     * 第三方 专属接口
+     *
+     * 获取成员授权列表,当企业当前授权模式为成员授权时，可调用该接口获取成员授权列表。
+     *
+     * https://work.weixin.qq.com/api/doc/90001/90143/94513
+     *
+     * @param param 请求参数
+     * @return {@link AuthMemberListResp}
+     */
+    @RequestLine(BaseApiUris.API_USER_AUTH_MEMBER_LIST)
+    AuthMemberListResp getAuthMemberList(AuthMemberListParam param);
+
+    /**
+     *  第三方 专属接口
+     *
+     * 查询成员用户是否已授权
+     *
+     * 当企业当前授权模式为成员授权时，可调用该接口查询成员用户是否已授权
+     *
+     * https://work.weixin.qq.com/api/doc/90001/90143/94514
+     *
+     * @param param 请求参数
+     * @return {@link CheckMemberAuthResp}
+     */
+    @RequestLine(BaseApiUris.API_USER_CHECK_MEMBER_AUTH)
+    CheckMemberAuthResp checkMemberAuth(CheckMemberAuthParam param);
 }

--- a/qiye-wechat-spring-boot-starter/pom.xml
+++ b/qiye-wechat-spring-boot-starter/pom.xml
@@ -51,4 +51,29 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- 跳过单元测试 -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <skipTests>true</skipTests>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+
+                </plugin>
+
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>


### PR DESCRIPTION
1. 修改pom.xml maven build 插件配置，解决 isntall 失败等问题
2. 修改 ContactUserApi.java 参数注解，解决 java.lang.IllegalStateException: PathVariable annotation was empty on param 0 异常。